### PR TITLE
Docker container

### DIFF
--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -1,123 +1,73 @@
-# Start with a base Debian image
-FROM debian:bookworm-slim
+# Use continuumio/miniconda3 as the base image
+FROM continuumio/miniconda3
 
-# Set environment variables to non-interactive (this prevents some prompts)
-ENV DEBIAN_FRONTEND=noninteractive
+LABEL maintainer="Richard Morris <richard.morris@anu.edu.au>"
 
-# Update the package list and install necessary dependencies for building Python packages and zsh
-# require root access
-RUN apt-get update && \
-    apt-get install -y \
-    build-essential \
-    libssl-dev \
-    libffi-dev \
-    zlib1g-dev \
-    libncurses5-dev \
-    libgdbm-dev \
-    libnss3-dev \
-    libssl-dev \
-    libreadline-dev \
-    libffi-dev \
-    curl \
-    wget \
-    zsh \
-    git \
-    autojump && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Install required packages
+RUN apt-get update -q && \
+    apt-get install -q -y --no-install-recommends \
+        git \
+        zsh \
+        wget \
+        curl \
+        sudo \
+        openssh-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Download and install Python 3.12 from source (Python 3.12 is not currently avaialble in the Debian package repository)
-WORKDIR /tmp
-RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz
-RUN tar -xvf Python-3.12.0.tgz
-WORKDIR /tmp/Python-3.12.0
-RUN ./configure --enable-optimizations
-RUN make altinstall
-WORKDIR /
-RUN rm -rf /tmp/Python-3.12.0
+# Set up a non-root user with sudo access
+RUN useradd -m user && \
+    echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Set Python 3.12 as the default Python version: requires root
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.12 1
+# Switch to the non-root user
+USER user
+WORKDIR /home/user
 
+# Set up zsh as the default shell
+SHELL ["/bin/zsh", "-c"]
 
-# install sudo so we can create a non root account to use as default
-RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
-
-# Create a non-root user
-ARG USERNAME=user
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN groupadd --gid $USER_GID $USERNAME && \
-    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
-    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME && \
-    chmod 0440 /etc/sudoers.d/$USERNAME
-
-# Install Miniforge
-RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \
-    sudo bash miniforge.sh -b -p /miniforge && \
-    rm miniforge.sh && \
-    . /miniforge/etc/profile.d/conda.sh && \
-# update conda to the latest version
-    conda update -n base -c conda-forge conda && \
-# Prevent auto-activation of the base environment
-    conda config --set auto_activate_base false
-
-# Add Miniforge to PATH
-ENV PATH="/miniforge/bin:${PATH}"
-
-# Switch to non-root user
-USER $USERNAME
-
-# Create repos directory and clone the repositories
-RUN mkdir /home/$USERNAME/repos && \
-    git clone --branch master https://github.com/cogent3/EnsemblLite.git /home/$USERNAME/repos/EnsemblLite && \
-    git clone --branch develop https://github.com/cogent3/cogent3.git /home/$USERNAME/repos/cogent3
-
-# Create a new conda environment named c312
-RUN . /miniforge/etc/profile.d/conda.sh && \
-    conda create -n c312 python=3.12 -y && \
-    conda activate c312 && \
-    mamba install flit jupyter ipykernel unsync click 
-    # cd /home/$USERNAME/repos/EnsemblLite && \
-    # flit install -s --python $(which python) && \
-    # cd /home/$USERNAME/repos/cogent3 && \
-    # flit install -s --python $(which python)
-
-# Initialize conda for bash shell interaction with c312 environment
-RUN echo ". /miniforge/etc/profile.d/conda.sh" >> $HOME/.bashrc && \
-    echo "conda activate c312" >> $HOME/.bashrc
-
-# # Install cogent3 and EnsemblLite from the cloned repositories in the c312 environment
-# RUN cd /home/$USERNAME/repos/EnsemblLite && \
-#     flit install -s --python $(which python) && \
-#     cd /home/$USERNAME/repos/cogent3 && \
-#     flit install -s --python $(which python)
-      
 # Install Oh My Zsh
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+RUN sh -c "$(wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)" "" --unattended
 
-# Set zsh as the default shell
-SHELL ["/usr/bin/zsh", "-c"]
+# Install zsh autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 
-# Create a default .zshrc file with some suggested configurations
-RUN echo 'export ZSH="$HOME/.oh-my-zsh"' >> $HOME/.zshrc && \
-    echo 'ZSH_THEME="robbyrussell"' >> $HOME/.zshrc && \
-    echo 'plugins=(git zsh-autosuggestions zsh-syntax-highlighting autojump)' >> $HOME/.zshrc && \
-    echo 'source $ZSH/oh-my-zsh.sh' >> $HOME/.zshrc && \
-    echo 'export HISTFILE=~/.zsh_history' >> $HOME/.zshrc && \
-    echo 'export HISTSIZE=10000' >> $HOME/.zshrc && \
-    echo 'export SAVEHIST=10000' >> $HOME/.zshrc && \
-    echo 'setopt appendhistory' >> $HOME/.zshrc && \
-    echo 'setopt histignorespace' >> $HOME/.zshrc && \
-    echo 'setopt histignorealldups' >> $HOME/.zshrc && \
-# Initialize conda for zsh shell interaction
-    echo ". /miniforge/etc/profile.d/conda.sh" >> $HOME/.zshrc && \
-    echo "conda activate c312" >> $HOME/.zshrc
+# Install zsh syntax highlighting
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+
+# Configure zsh
+RUN sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions zsh-syntax-highlighting)/' ~/.zshrc
+
+# Create a new conda environment with Python 3.12
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    /opt/conda/bin/conda create -n c312 python=3.12 -y && \
+    conda activate c312
+
+
+# Initialize conda for zsh shell
+RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.zshrc && \
+    echo "conda activate c312" >> ~/.zshrc
+
+# Clone the repositories using SSH
+WORKDIR /home/user/repos
+RUN git clone --branch develop https://github.com/cogent3/cogent3.git /home/$USERNAME/repos/cogent3 && \
+    git clone --branch master https://github.com/cogent3/EnsemblLite.git /home/$USERNAME/repos/EnsemblLite
+
+# Install flit in the conda environment
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate c312 && \
+    conda install -c conda-forge flit -y
     
-# Install zsh-autosuggestions and zsh-syntax-highlighting plugins
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions && \
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+# Install the repositories using flit
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate c312 && \
+    cd /home/user/repos/cogent3 && \
+    flit install -s && \
+    cd /home/user/repos/EnsemblLite && \
+    flit install -s
 
-# Start a terminal session using the zsh shell
-CMD ["/usr/bin/zsh"]
+# Start in the home directory     
+WORKDIR /home/user
+
+# Set zsh as the default shell for the container
+CMD [ "zsh" ]

--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -8,23 +8,37 @@ ENV DEBIAN_FRONTEND=noninteractive
 # require root access
 RUN apt-get update && \
     apt-get install -y \
-    python3.11 \
-    python3.11-dev \
-    python3-pip \
-    python3-venv \  
     build-essential \
     libssl-dev \
     libffi-dev \
-    python3-dev \
-    zsh \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libreadline-dev \
+    libffi-dev \
     curl \
+    wget \
+    zsh \
     git \
     autojump && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Set Python 3.11 as the default Python version: requires root
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+# Download and install Python 3.12 from source (Python 3.12 is not currently avaialble in the Debian package repository)
+WORKDIR /tmp
+RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz
+RUN tar -xvf Python-3.12.0.tgz
+WORKDIR /tmp/Python-3.12.0
+RUN ./configure --enable-optimizations
+RUN make altinstall
+WORKDIR /
+RUN rm -rf /tmp/Python-3.12.0
+
+# Set Python 3.12 as the default Python version: requires root
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.12 1
+
 
 # install sudo so we can create a non root account to use as default
 RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
@@ -39,15 +53,47 @@ RUN groupadd --gid $USER_GID $USERNAME && \
     echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME && \
     chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Install Miniforge
+RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \
+    sudo bash miniforge.sh -b -p /miniforge && \
+    rm miniforge.sh && \
+    . /miniforge/etc/profile.d/conda.sh && \
+# update conda to the latest version
+    conda update -n base -c conda-forge conda && \
+# Prevent auto-activation of the base environment
+    conda config --set auto_activate_base false
+
+# Add Miniforge to PATH
+ENV PATH="/miniforge/bin:${PATH}"
+
 # Switch to non-root user
 USER $USERNAME
 
-# Create the virtual environment, activate it, and install packages
-RUN python3 -m venv /home/user/c3 && \
-    . /home/user/c3/bin/activate && \
-    pip install --upgrade pip && \
-    pip install "cogent3[extra]" flit jupyter ipykernel unsync click
+# Create repos directory and clone the repositories
+RUN mkdir /home/$USERNAME/repos && \
+    git clone --branch master https://github.com/cogent3/EnsemblLite.git /home/$USERNAME/repos/EnsemblLite && \
+    git clone --branch develop https://github.com/cogent3/cogent3.git /home/$USERNAME/repos/cogent3
 
+# Create a new conda environment named c312
+RUN . /miniforge/etc/profile.d/conda.sh && \
+    conda create -n c312 python=3.12 -y && \
+    conda activate c312 && \
+    mamba install flit jupyter ipykernel unsync click 
+    # cd /home/$USERNAME/repos/EnsemblLite && \
+    # flit install -s --python $(which python) && \
+    # cd /home/$USERNAME/repos/cogent3 && \
+    # flit install -s --python $(which python)
+
+# Initialize conda for bash shell interaction with c312 environment
+RUN echo ". /miniforge/etc/profile.d/conda.sh" >> $HOME/.bashrc && \
+    echo "conda activate c312" >> $HOME/.bashrc
+
+# # Install cogent3 and EnsemblLite from the cloned repositories in the c312 environment
+# RUN cd /home/$USERNAME/repos/EnsemblLite && \
+#     flit install -s --python $(which python) && \
+#     cd /home/$USERNAME/repos/cogent3 && \
+#     flit install -s --python $(which python)
+      
 # Install Oh My Zsh
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 
@@ -65,18 +111,13 @@ RUN echo 'export ZSH="$HOME/.oh-my-zsh"' >> $HOME/.zshrc && \
     echo 'setopt appendhistory' >> $HOME/.zshrc && \
     echo 'setopt histignorespace' >> $HOME/.zshrc && \
     echo 'setopt histignorealldups' >> $HOME/.zshrc && \
-    echo 'source /home/user/c3/bin/activate' >> $HOME/.zshrc
-
+# Initialize conda for zsh shell interaction
+    echo ". /miniforge/etc/profile.d/conda.sh" >> $HOME/.zshrc && \
+    echo "conda activate c312" >> $HOME/.zshrc
+    
 # Install zsh-autosuggestions and zsh-syntax-highlighting plugins
 RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions && \
     git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
-# Add venv to bash and zsh shells
-RUN echo 'source /home/user/c3/bin/activate' >> /home/user/.bashrc && \
-    echo 'source /home/user/c3/bin/activate' >> /home/user/.zshrc
-
-# Set up a working directory
-WORKDIR /workspace/Cogent3Workshop
-
 # Start a terminal session using the zsh shell
-CMD ["/usr/bin/zsh"] 
+CMD ["/usr/bin/zsh"]

--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -1,0 +1,82 @@
+# Start with a base Debian image
+FROM debian:bookworm-slim
+
+# Set environment variables to non-interactive (this prevents some prompts)
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update the package list and install necessary dependencies for building Python packages and zsh
+# require root access
+RUN apt-get update && \
+    apt-get install -y \
+    python3.11 \
+    python3.11-dev \
+    python3-pip \
+    python3-venv \  
+    build-essential \
+    libssl-dev \
+    libffi-dev \
+    python3-dev \
+    zsh \
+    curl \
+    git \
+    autojump && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set Python 3.11 as the default Python version: requires root
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+
+# install sudo so we can create a non root account to use as default
+RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Switch to non-root user
+USER $USERNAME
+
+# Create the virtual environment, activate it, and install packages
+RUN python3 -m venv /home/user/c3 && \
+    . /home/user/c3/bin/activate && \
+    pip install --upgrade pip && \
+    pip install "cogent3[extra]" flit jupyter ipykernel unsync click
+
+# Install Oh My Zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Set zsh as the default shell
+SHELL ["/usr/bin/zsh", "-c"]
+
+# Create a default .zshrc file with some suggested configurations
+RUN echo 'export ZSH="$HOME/.oh-my-zsh"' >> $HOME/.zshrc && \
+    echo 'ZSH_THEME="robbyrussell"' >> $HOME/.zshrc && \
+    echo 'plugins=(git zsh-autosuggestions zsh-syntax-highlighting autojump)' >> $HOME/.zshrc && \
+    echo 'source $ZSH/oh-my-zsh.sh' >> $HOME/.zshrc && \
+    echo 'export HISTFILE=~/.zsh_history' >> $HOME/.zshrc && \
+    echo 'export HISTSIZE=10000' >> $HOME/.zshrc && \
+    echo 'export SAVEHIST=10000' >> $HOME/.zshrc && \
+    echo 'setopt appendhistory' >> $HOME/.zshrc && \
+    echo 'setopt histignorespace' >> $HOME/.zshrc && \
+    echo 'setopt histignorealldups' >> $HOME/.zshrc && \
+    echo 'source /home/user/c3/bin/activate' >> $HOME/.zshrc
+
+# Install zsh-autosuggestions and zsh-syntax-highlighting plugins
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions && \
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+
+# Add venv to bash and zsh shells
+RUN echo 'source /home/user/c3/bin/activate' >> /home/user/.bashrc && \
+    echo 'source /home/user/c3/bin/activate' >> /home/user/.zshrc
+
+# Set up a working directory
+WORKDIR /workspace/Cogent3Workshop
+
+# Start a terminal session using the zsh shell
+CMD ["/usr/bin/zsh"] 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,5 +1,36 @@
-# Cogent3 workshop Devcontainer
+# Cogent3 workshop Development container for cogent3 and EnsemblLite
 
-This folder contains a Docker configuration file for setting up the workshop environment for working with Cogent3 in a docker container, and a `devcontainer.json` configuration so that VS Code can manage the container.  The container installs the latest release of cogent3.  It also pre-populates VS code extensions for jupiter notebooks and for working with python.
+This folder contains a Docker configuration file for setting up the workshop environment for working with `cogent3` and `EnsemblLite` in a docker container, and a `devcontainer.json` configuration so that VS Code can manage the container.  The container installs the develop branch of `cogent3`, and the master branch of `EnsemblLite`.  It also pre-populates VS code extensions for jupiter notebooks and for working with python.
 
 For instructions for building this docker image into a container to run the workshop, see the [Computer setup instructions](https://github.com/cogent3/Cogent3Workshop/wiki/Computer-Setup).
+
+## Container description
+
+This development container is designed to provide a consistent and reproducible development environment for working with the    `cogent3` and `EnsemblLite` Python packages. It is based on a slim Debian image and includes a variety of tools and configurations to facilitate development.
+
+- Base Image: The base image is debian:bookworm-slim, a slim version of the latest Debian release.
+- Python: Python 3.12 is installed and set as the default Python version.
+- Non-root User: A non-root user named user is created for running the container. This is a good security practice.
+- Repositories: The cogent3 and EnsemblLite repositories are cloned into the /home/user/repos directory.
+- Miniforge: Miniforge is installed to manage Python environments and packages. The base environment is not auto-activated.
+- Conda Environment: A new conda environment named c312 is created with Python 3.12. This environment is activated when a new shell is started.
+- Packages: Several packages are installed in the c312 environment using mamba, including flit, jupyter, ipykernel, unsync, and click.
+- `cogent3` and `EnsemblLite`: The `cogent3` and `EnsemblLite` packages are installed from the cloned repositories in the c312 environment using flit.
+- Zsh and Oh My Zsh: The Zsh shell is installed and set as the default shell. Oh My Zsh is installed for additional shell features and configurations. Several plugins are enabled, including git, zsh-autosuggestions, zsh-syntax-highlighting, and autojump.
+
+## Using the Container
+
+To use the container, you can load your clone of the workshop repository in VS-Code and you will be asked if you want to run in a devcontainer.  When you select yes, VS-Code will rebuild the container, start it, remote connect into the container, and open a new VS-Code window in the container.  You can then open a terminal in the container and you should automatically be in the zsh shell, in the mamba c312 environment, logged in as the user `User`, and in the directory /workspaces/$workshopname$ with the workshop files.  You can navigate to the the /home/user/repos directory to access the cogent3 and EnsemblLite repositories.
+
+## Configuring Resource Allocation
+
+You can configure the resource used for the development container by modifying the `devcontainer.json` file. This file allows you to specify the number of CPUs and the amount of RAM the container can use.
+
+Steps
+
+- Open the devcontainer.json file in your editor.
+- Look for the runArgs property. by default it is set to `    "runArgs": ["--cpus", "1", "-m", "4g"],`, which is 1 cpu and 4GB of RAM.
+- To limit the number of CPUs the container can use, add "--cpus" and "2" (or your desired number of CPUs) to the runArgs array.
+- To limit the amount of RAM the container can use, add "-m" and "4g" (or your desired amount of RAM) to the runArgs array.
+
+Please note that these settings will only limit the maximum resources a container can use. The container will use less resources if it doesn't need the maximum amount.  Also, please make sure that your Docker host has enough resources to allocate to the container. If the host doesn't have enough resources, the container may not start.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -29,8 +29,8 @@ You can configure the resource used for the development container by modifying t
 Steps
 
 - Open the devcontainer.json file in your editor.
-- Look for the runArgs property. by default it is set to `    "runArgs": ["--cpus", "1", "-m", "4g"],`, which is 1 cpu and 4GB of RAM.
-- To limit the number of CPUs the container can use, add "--cpus" and "2" (or your desired number of CPUs) to the runArgs array.
+- Look for the runArgs property. by default it is set to `    "runArgs": ["--cpus", "2", "-m", "4g"],`, which is 2 cpu and 4GB of RAM.
+- To limit the number of CPUs the container can use, add "--cpus" and your desired number of CPUs to the runArgs array.
 - To limit the amount of RAM the container can use, add "-m" and "4g" (or your desired amount of RAM) to the runArgs array.
 
 Please note that these settings will only limit the maximum resources a container can use. The container will use less resources if it doesn't need the maximum amount.  Also, please make sure that your Docker host has enough resources to allocate to the container. If the host doesn't have enough resources, the container may not start.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,5 @@
+# Cogent3 workshop Devcontainer
+
+This folder contains a Docker configuration file for setting up the workshop environment for working with Cogent3 in a docker container, and a `devcontainer.json` configuration so that VS Code can manage the container.  The container installs the latest release of cogent3.  It also pre-populates VS code extensions for jupiter notebooks and for working with python.
+
+For instructions for building this docker image into a container to run the workshop, see the [Computer setup instructions](https://github.com/cogent3/Cogent3Workshop/wiki/Computer-Setup).

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -4,24 +4,6 @@ This folder contains a Docker configuration file for setting up the workshop env
 
 For instructions for building this docker image into a container to run the workshop, see the [Computer setup instructions](https://github.com/cogent3/Cogent3Workshop/wiki/Computer-Setup).
 
-## Container description
-
-This development container is designed to provide a consistent and reproducible development environment for working with the    `cogent3` and `EnsemblLite` Python packages. It is based on a slim Debian image and includes a variety of tools and configurations to facilitate development.
-
-- Base Image: The base image is debian:bookworm-slim, a slim version of the latest Debian release.
-- Python: Python 3.12 is installed and set as the default Python version.
-- Non-root User: A non-root user named user is created for running the container. This is a good security practice.
-- Repositories: The cogent3 and EnsemblLite repositories are cloned into the /home/user/repos directory.
-- Miniforge: Miniforge is installed to manage Python environments and packages. The base environment is not auto-activated.
-- Conda Environment: A new conda environment named c312 is created with Python 3.12. This environment is activated when a new shell is started.
-- Packages: Several packages are installed in the c312 environment using mamba, including flit, jupyter, ipykernel, unsync, and click.
-- `cogent3` and `EnsemblLite`: The `cogent3` and `EnsemblLite` packages are installed from the cloned repositories in the c312 environment using flit.
-- Zsh and Oh My Zsh: The Zsh shell is installed and set as the default shell. Oh My Zsh is installed for additional shell features and configurations. Several plugins are enabled, including git, zsh-autosuggestions, zsh-syntax-highlighting, and autojump.
-
-## Using the Container
-
-To use the container, you can load your clone of the workshop repository in VS-Code and you will be asked if you want to run in a devcontainer.  When you select yes, VS-Code will rebuild the container, start it, remote connect into the container, and open a new VS-Code window in the container.  You can then open a terminal in the container and you should automatically be in the zsh shell, in the mamba c312 environment, logged in as the user `User`, and in the directory /workspaces/$workshopname$ with the workshop files.  You can navigate to the the /home/user/repos directory to access the cogent3 and EnsemblLite repositories.
-
 ## Configuring Resource Allocation
 
 You can configure the resource used for the development container by modifying the `devcontainer.json` file. This file allows you to specify the number of CPUs and the amount of RAM the container can use.
@@ -34,3 +16,21 @@ Steps
 - To limit the amount of RAM the container can use, add "-m" and "4g" (or your desired amount of RAM) to the runArgs array.
 
 Please note that these settings will only limit the maximum resources a container can use. The container will use less resources if it doesn't need the maximum amount.  Also, please make sure that your Docker host has enough resources to allocate to the container. If the host doesn't have enough resources, the container may not start.
+
+## Container description
+
+This development container is designed to provide a consistent and reproducible development environment for working with the    `cogent3` and `EnsemblLite` Python packages. It is based on a slim Debian image and includes a variety of tools and configurations to facilitate development.
+
+- Base Image: The base image is continuumIO/miniconda3 which is based on debian:bookworm-slim, a slim version of the latest Debian release.
+- Python: Python 3.12 is installed and set as the default Python version.
+- Non-root User: A non-root user named user is created for running the container. This is a good security practice.
+- Repositories: The cogent3 and EnsemblLite repositories are cloned into the /home/user/repos directory.
+- Conda Environment: A new conda environment named c312 is created with Python 3.12. This environment is activated when a new shell is started.
+- Packages: Flit is installed in the c312 environment 
+- `cogent3` and `EnsemblLite`: The `cogent3` and `EnsemblLite` packages are installed from the cloned repositories in the c312 environment using flit.
+- Zsh and Oh My Zsh: The Zsh shell is installed and set as the default shell. Oh My Zsh is installed for additional shell features and configurations. Several plugins are enabled, including git, zsh-autosuggestions, zsh-syntax-highlighting, and autojump.
+
+## Using the Container
+
+To use the container, you can load your clone of the workshop repository in VS-Code and you will be asked if you want to run in a devcontainer.  When you select yes, VS-Code will rebuild the container, start it, remote connect into the container, and open a new VS-Code window in the container.  You can then open a terminal in the container and you should automatically be in the zsh shell, in the mamba c312 environment, logged in as the user `User`, and in the directory /workspaces/$workshopname$ with the workshop files.  You can navigate to the the /home/user/repos directory to access the cogent3 and EnsemblLite repositories.
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
       "dockerfile": "Dockerfile",
       "context": ".."
     },
+    "runArgs": ["--cpus", "2", "-m", "4g"],
     "settings": {
       "terminal.integrated.defaultProfile.linux": "zsh",
       "terminal.integrated.profiles.linux": {
@@ -11,12 +12,12 @@
           "path": "zsh"
         }
       },
-      "python.defaultInterpreterPath": "/home/user/c3/bin/python",
+      "python.defaultInterpreterPath": "/home/user/miniforge3/envs/c312/bin/python",
     },
     "extensions": [
       "ms-python.python",
       "ms-toolsai.jupyter"
     ],
     "remoteUser": "user",
-    "postStartCommand": "echo 'Cogent3 Workshop 2023 environment is ready!'"
+    "postStartCommand": "echo 'Cogent3 Workshop 2023 environment is ready!'",
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "Cogent3 Workshop",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "context": ".."
+    },
+    "settings": {
+      "terminal.integrated.defaultProfile.linux": "zsh",
+      "terminal.integrated.profiles.linux": {
+        "zsh": {
+          "path": "zsh"
+        }
+      },
+      "python.defaultInterpreterPath": "/home/user/c3/bin/python",
+    },
+    "extensions": [
+      "ms-python.python",
+      "ms-toolsai.jupyter"
+    ],
+    "remoteUser": "user",
+    "postStartCommand": "echo 'Cogent3 Workshop 2023 environment is ready!'"
+  }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,21 +3,22 @@
     "build": {
       "dockerfile": "Dockerfile",
       "context": ".."
-    },
+    },    
     "runArgs": ["--cpus", "2", "-m", "4g"],
-    "settings": {
+    "
+    settings": {
       "terminal.integrated.defaultProfile.linux": "zsh",
       "terminal.integrated.profiles.linux": {
         "zsh": {
           "path": "zsh"
         }
       },
-      "python.defaultInterpreterPath": "/home/user/miniforge3/envs/c312/bin/python",
+      "python.defaultInterpreterPath": "/home/user/.conda/envs/c312/bin/python",
     },
     "extensions": [
       "ms-python.python",
       "ms-toolsai.jupyter"
     ],
     "remoteUser": "user",
-    "postStartCommand": "echo 'Cogent3 Workshop 2023 environment is ready!'",
+    "postStartCommand": "echo 'Cogent3 Workshop 2024 environment is ready!'"
   }


### PR DESCRIPTION
devcontainer.json
-  sets cpu and memory constraints for docker runargs
- sets zsh as the default shell
- sets the default python interpreter to the c312 interpreter
- installs python and jupyter extensions

DockerFile 
- uses the canonical miniconda3 image as base
- sets up a passwordless user with sudo access and switches to it
- sets zsh as the shell (with oh my zsh + autosuggestions and syntax highlighting)
- creates a conda env c312 using python 3.12
- clones and flit installs cogent3 and EnsemblLite
- 